### PR TITLE
Update CLI version to 3.4.4

### DIFF
--- a/Formula/rainforest-cli.rb
+++ b/Formula/rainforest-cli.rb
@@ -1,8 +1,8 @@
 class RainforestCli < Formula
   desc "Rainforest QA command line interface"
   homepage "https://github.com/rainforestapp/rainforest-cli"
-  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.4.3/rainforest-cli-3.4.3-darwin-amd64.tar.gz"
-  sha256 "0cdf42223d75cc53df64b3c8a0895386c309a8d907469c790c97556c132fa0f3"
+  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.4.4/rainforest-cli-3.4.4-darwin-amd64.tar.gz"
+  sha256 "fecf7ff0b97bf179c6830b7b0d0a9bbd59e0d35b7c7e62ba44709a44a60e8de2"
 
   def install
     bin.install "rainforest"


### PR DESCRIPTION
New Version of Rainforest-CLi has been released. 
https://github.com/rainforestapp/rainforest-cli/releases/tag/v3.4.4