### PR TITLE
Update CLI to 3.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,16 +2,16 @@ on:
   - pull_request
 jobs:
   install_formula:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
-      - 
+      -
         name: Checkout
         uses: actions/checkout@v2
-      - 
+      -
         name: Install rainforest-cli
         run: |
           brew install --formula ./Formula/rainforest-cli.rb
-      - 
+      -
         name: Check rainforest works
         env:
           URL: ${{ github.event.pull_request.comments_url }}

--- a/Formula/rainforest-cli.rb
+++ b/Formula/rainforest-cli.rb
@@ -1,8 +1,8 @@
 class RainforestCli < Formula
   desc "Rainforest QA command line interface"
   homepage "https://github.com/rainforestapp/rainforest-cli"
-  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.5.1/rainforest-cli-3.5.1-darwin-amd64.tar.gz"
-  sha256 "2fb22b3d3ea7bd3729f2b261b7b4c5aa9169081328bfe805e1ab58bb2da001fe"
+  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.6.0/rainforest-cli-3.6.0-darwin-amd64.tar.gz"
+  sha256 "6639665f232d8987004f041070191a825177fe19bd3a2bba96d4176a7e049f39"
 
   def install
     bin.install "rainforest"


### PR DESCRIPTION
CLI release: https://github.com/rainforestapp/rainforest-cli/releases/tag/v3.6.0

Checksums: https://app.circleci.com/pipelines/github/rainforestapp/rainforest-cli/562/workflows/637f71c6-2da3-47b8-a356-7becc7116bea/jobs/5624/parallel-runs/0/steps/0-104