### PR TITLE
Update CLI to v3.6.2

### DIFF
--- a/Formula/rainforest-cli.rb
+++ b/Formula/rainforest-cli.rb
@@ -1,8 +1,8 @@
 class RainforestCli < Formula
   desc "Rainforest QA command line interface"
   homepage "https://github.com/rainforestapp/rainforest-cli"
-  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.6.1/rainforest-cli-3.6.1-darwin-amd64.tar.gz"
-  sha256 "d77c69a9572570cd0513bb7181cbed0e947665986c71d4743ba114c994130517"
+  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.6.2/rainforest-cli-3.6.2-darwin-amd64.tar.gz"
+  sha256 "f1a6f91d3fb446aac3512895f57ab1b523c354f7499df66bf21a1432a8caa87b"
 
   def install
     bin.install "rainforest"


### PR DESCRIPTION
CLI Release: https://github.com/rainforestapp/rainforest-cli/releases/tag/v3.6.2