### PR TITLE
Update CLI to v3.7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,17 @@ on:
   - pull_request
 jobs:
   install_formula:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       -
         name: Install rainforest-cli
         run: |
-          brew install --formula ./Formula/rainforest-cli.rb
+          brew tap --custom-remote rainforestapp/public $GITHUB_WORKSPACE
+          brew info rainforestapp/public/rainforest-cli
+          brew install rainforestapp/public/rainforest-cli
       -
         name: Check rainforest works
         env:

--- a/Formula/rainforest-cli.rb
+++ b/Formula/rainforest-cli.rb
@@ -1,8 +1,8 @@
 class RainforestCli < Formula
   desc "Rainforest QA command line interface"
   homepage "https://github.com/rainforestapp/rainforest-cli"
-  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.6.2/rainforest-cli-3.6.2-darwin-amd64.tar.gz"
-  sha256 "f1a6f91d3fb446aac3512895f57ab1b523c354f7499df66bf21a1432a8caa87b"
+  url "https://github.com/rainforestapp/rainforest-cli/releases/download/v3.7.0/rainforest-cli-3.7.0-darwin-amd64.tar.gz"
+  sha256 "6da200c849c0b47029528dd83638c28ca430911d00f6fd55b4f616c43af2ed8e"
 
   def install
     bin.install "rainforest"


### PR DESCRIPTION
- https://github.com/rainforestapp/rainforest-cli/releases/tag/v3.7.0
- Also changed machine for GitHub action to use macOS 15 Intel, as macOS 13 has been deprecated.